### PR TITLE
Config wrapper, Warn function, and Original Stack Frame

### DIFF
--- a/nonstdlib/debug.py
+++ b/nonstdlib/debug.py
@@ -60,6 +60,9 @@ def debug(message, **kwargs):
 def info(message, **kwargs):
     _log(logging.INFO, message, **kwargs)
 
+def warn(message, **kwargs):
+    return _log(logging.WARNING, message, **kwargs)
+
 def warning(message, **kwargs):
     _log(logging.WARNING, message, **kwargs)
 

--- a/nonstdlib/debug.py
+++ b/nonstdlib/debug.py
@@ -103,7 +103,7 @@ def _log(level, message, frame_depth=2, **kwargs):
 
         name = frame.f_globals['__name__']
         self = frame.f_locals.get('self')
-        function = inspect.getframeinfo(frame).function
+        filename, lineno, function, _, _ = inspect.getframeinfo(frame)
 
         if self is not None:
             name += '.' + self.__class__.__name__


### PR DESCRIPTION
* Added config function.
  - Wraps basicConfig and allows setting a stream and file handler with one call.
  - Can be used for only setting one as well.
* Added warn function.
  - I know logging.warn is deprecated, but I like the option to type warn rather than warning.
  - debug.warn using logging.warning, not the deprecated warn.
* Retrieve the original filename and lineno of the logging call.
  - In order to use format options such as %(lineno)s, we have to retrieve the original line no from the call stack.
  - I'm retrieving the values, now they need to be passed to the created Logger somehow.